### PR TITLE
Setup get.tensara.org subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # CLI for Tensara submissions (Beta)
 
-Currently in beta. Allow users to practice Tensara problems from th e comfort of their own IDE. 
+Currently in beta. Allow users to practice Tensara problems from th e comfort of their own IDE.
 For now, CLI submissions do not show up on the leaderboard. Actively working on this, expect updates in 2 weeks!
 
 ## Install
 For Linux/Mac:
 ```bash
-curl -sSL https://tensara.github.io/tensara-cli/install.sh | bash
+curl -sSL https://get.tensara.org/install.sh | bash
 ```
 
 For Windows (untested):
 ```bash
-iwr -useb https://tensara.github.io/tensara-cli/install.ps1 | iex
+iwr -useb https://get.tensara.org/install.sh | iex
 ```
 
 
@@ -21,7 +21,7 @@ Run:
 ``` bash
 tensara
 ```
-or 
+or
 ``` bash
 tensara --help
 ```
@@ -40,7 +40,7 @@ tensara checker -g T4 --problem vector-addition --solution tests/sol.cu
 Short forms for args are also supported:
 
 ```bash
-tensara checker -g T4 -p vector-addition -s tests/sol.cu 
+tensara checker -g T4 -p vector-addition -s tests/sol.cu
 ```
 
 Supports the same languages and GPUS as the Tensara engine.


### PR DESCRIPTION
Custom `curl | bash` installation domain, which can be used like this:

```
curl -sSL https://get.tensara.org/install.sh | bash
```

or this (on Windows):

```
iwr -useb https://get.tensara.org/install.sh | iex
```